### PR TITLE
Update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const ModalExamplePage = () => (
   </ModalRoutingContext>
 )
 
-exports default ModalExamplePage
+export default ModalExamplePage
 ```
 
 ### Opening a page in a modal


### PR DESCRIPTION
Replace `exports default` with `export default` in README example