### PR TITLE
remove prevRouterProps from shouldUpdateScroll

### DIFF
--- a/src/shouldUpdateScroll.js
+++ b/src/shouldUpdateScroll.js
@@ -1,7 +1,6 @@
 import _ from 'lodash'
 
 const shouldUpdateScroll = ({
-  prevRouterProps: { location: prevLocation },
   routerProps: { location }
 }) => {
   const isModal = _.get(location, 'state.modal')


### PR DESCRIPTION
1. prevRouterProps's location cause an error when address contains section path e.g type: localhost:8000/#test
2. prevRouterProps is unused in project