### PR TITLE
Fix default context value when not in a modal

### DIFF
--- a/src/ModalRoutingContext.js
+++ b/src/ModalRoutingContext.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const defaultValue = {
-  isModal: false,
+  modal: false,
   closeTo: null,
 }
 const ModalRoutingContext = React.createContext(defaultValue)


### PR DESCRIPTION
I noticed the context value for `modal` was undefined instead of false when outside a modal.